### PR TITLE
fix: extra seconds at each interval

### DIFF
--- a/src/Pomodoro.CLI/Program.cs
+++ b/src/Pomodoro.CLI/Program.cs
@@ -7,8 +7,6 @@ public class Program
 {
   public static void Main()
   {
-    var workInterval = TimeSpan.FromMinutes(0.1);
-    var breakInterval = TimeSpan.FromMinutes(0.1);
     var settings = new Settings();
     var task = new Task("Work", settings, 2);
     var taskCompleted = new ManualResetEvent(false);
@@ -31,7 +29,7 @@ public class Program
       Console.WriteLine($"Actual time: {DateTime.Now}");
       Console.WriteLine($"Is Work time completed: {task.CurrentActiveTimer.WorkInterval.IsCompleted}");
       Console.WriteLine($"Is Break time completed: {task.CurrentActiveTimer.BreakInterval.IsCompleted}");
-      Console.WriteLine($"Is Break Auto Start on: {task.CurrentActiveTimer.AutoStartBreak}");
+      Console.WriteLine($"Is Break Auto Start on: {task.CurrentActiveTimer.Settings.AutoStartBreak}");
 
       if (task.IsCompleted() || task.CurrentActiveTimer.IsCompleted)
       {

--- a/src/Pomodoro.Core/Entities/Clock.cs
+++ b/src/Pomodoro.Core/Entities/Clock.cs
@@ -10,26 +10,33 @@ public class Clock
 
   private readonly ClockTimer _clockTimer;
 
-  public EClockTimerStates CurrentState = EClockTimerStates.Work;
+  public Settings Settings { get; private set; }
 
-  public bool AutoStartBreak { get; set; } = true;
+  public EClockTimerStates CurrentState = EClockTimerStates.Work;
 
   public WorkInterval WorkInterval { get; private set; }
 
   public BreakInterval BreakInterval { get; private set; }
 
-  public bool IsCompleted => WorkInterval.IsCompleted && BreakInterval.IsCompleted;
+  public bool IsCompleted =>
+    WorkInterval.IsCompleted
+    && BreakInterval.IsCompleted;
 
   public DateTime StartDate => WorkInterval.StartDate;
 
   public DateTime EndDate => BreakInterval.EndDate;
 
-  public event Action OnClockEnd;
+  public event Action OnClockEnd = () => { };
 
-  public Clock(TimeSpan workInterval, TimeSpan breakInterval)
+  public Clock(
+    TimeSpan workInterval,
+    TimeSpan breakInterval,
+    Settings settings
+  )
   {
     WorkInterval = new WorkInterval(workInterval);
     BreakInterval = new BreakInterval(breakInterval);
+    Settings = settings;
 
     _clockTimer = new ClockTimer(this);
   }
@@ -42,7 +49,10 @@ public class Clock
 
   public TimeSpan RemainingTime() => _clockTimer.RemainingTime();
 
-  public TimeSpan TotalElapsedTime() => IsCompleted ? EndDate - StartDate : DateTime.Now - StartDate;
+  public TimeSpan TotalElapsedTime() =>
+    IsCompleted
+      ? EndDate - StartDate
+      : DateTime.Now - StartDate;
 
   public void OnClockEnded() => OnClockEnd.Invoke();
 }

--- a/src/Pomodoro.Core/Entities/Task.cs
+++ b/src/Pomodoro.Core/Entities/Task.cs
@@ -28,7 +28,8 @@ public class Task
 
     var clock = new Clock(
       Settings.DefaultWorkTime,
-      Settings.DefaultBreakTime
+      Settings.DefaultBreakTime,
+      Settings
     );
     AddClock(clock);
 
@@ -43,7 +44,8 @@ public class Task
     {
       var clock = new Clock(
         Settings.DefaultWorkTime,
-        Settings.DefaultBreakTime
+        Settings.DefaultBreakTime,
+        Settings
       );
       AddClock(clock);
 

--- a/src/Pomodoro.Core/ValueObjects/ClockTimer/ClockTimer.cs
+++ b/src/Pomodoro.Core/ValueObjects/ClockTimer/ClockTimer.cs
@@ -8,7 +8,7 @@ public class ClockTimer
 {
   private readonly Clock _clock;
 
-  private CustomTimer _currentTimer;
+  private ClockTimerState _currentTimer;
 
   public ClockTimer(Clock clock)
   {
@@ -35,12 +35,8 @@ public class ClockTimer
 
     _clock.CurrentState = EClockTimerStates.Interval;
     _clock.BreakInterval.StartDate = e.SignalTime;
-    _clock.BreakInterval.IsActive = true;
 
-    if (_clock.AutoStartBreak)
-    {
-      _currentTimer.Start();
-    }
+    if (_clock.Settings.AutoStartBreak) _currentTimer.Start();
   }
 
   private void OnBreakElapsed(

--- a/src/Pomodoro.Core/ValueObjects/ClockTimer/ClockTimerState.cs
+++ b/src/Pomodoro.Core/ValueObjects/ClockTimer/ClockTimerState.cs
@@ -3,11 +3,14 @@
 using System.Timers;
 using Pomodoro.Core.Entities;
 
-public abstract class CustomTimer(Timer timer)
+public abstract class ClockTimerState(Timer timer)
 {
   protected Timer _timer = timer;
 
-  public event EventHandler<ElapsedEventArgs> OnElapsed;
+  public event EventHandler<ElapsedEventArgs> OnElapsed = (
+    object? sender,
+    ElapsedEventArgs eventArgs
+  ) => { };
 
   public abstract void Start();
 
@@ -23,7 +26,7 @@ public abstract class CustomTimer(Timer timer)
   ) => OnElapsed.Invoke(sender, eventArgs);
 }
 
-public class WorkState : CustomTimer
+public class WorkState : ClockTimerState
 {
   private readonly Clock _clock;
 
@@ -35,14 +38,14 @@ public class WorkState : CustomTimer
   }
 
   public override TimeSpan ElapsedTime() =>
-      _clock.WorkInterval.IsActive
-        ? DateTime.Now - _clock.WorkInterval.StartDate
-        : TimeSpan.Zero;
+    _clock.WorkInterval.IsActive
+      ? DateTime.Now - _clock.WorkInterval.StartDate
+      : TimeSpan.Zero;
 
   public override TimeSpan RemainingTime() =>
-      _clock.WorkInterval.IsActive
-        ? _clock.WorkInterval.StartDate.AddMinutes(_clock.WorkInterval.Duration.TotalMinutes) - DateTime.Now
-        : TimeSpan.Zero;
+    _clock.WorkInterval.IsActive
+      ? _clock.WorkInterval.StartDate.AddMinutes(_clock.WorkInterval.Duration.TotalMinutes) - DateTime.Now
+      : TimeSpan.Zero;
 
   public override void Start()
   {
@@ -71,7 +74,7 @@ public class WorkState : CustomTimer
   }
 }
 
-public class BreakState : CustomTimer
+public class BreakState : ClockTimerState
 {
   private readonly Clock _clock;
 
@@ -83,17 +86,14 @@ public class BreakState : CustomTimer
   }
 
   public override TimeSpan ElapsedTime() =>
-      _clock.BreakInterval.IsActive
-        ? DateTime.Now - _clock.BreakInterval.StartDate
-        : TimeSpan.Zero;
+    _clock.BreakInterval.IsActive
+      ? DateTime.Now - _clock.BreakInterval.StartDate
+      : TimeSpan.Zero;
 
-  public override TimeSpan RemainingTime()
-  {
-    return
-      _clock.BreakInterval.IsActive
-        ? _clock.BreakInterval.StartDate.AddMinutes(_clock.BreakInterval.Duration.TotalMinutes) - DateTime.Now
-        : TimeSpan.Zero;
-  }
+  public override TimeSpan RemainingTime() =>
+    _clock.BreakInterval.IsActive
+      ? _clock.BreakInterval.StartDate.AddMinutes(_clock.BreakInterval.Duration.TotalMinutes) - DateTime.Now
+      : TimeSpan.Zero;
 
   public override void Start()
   {


### PR DESCRIPTION
it turned out there was no bug in the code.
the "issue" was that we were creating a TimeSpan
using minutes instead of using seconds. Because of that, each interval was 6 seconds long.

closes #3 